### PR TITLE
Fix service name in ingress

### DIFF
--- a/k8s/ingress-nginx.yaml
+++ b/k8s/ingress-nginx.yaml
@@ -12,6 +12,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: nkubetest-takoyakidath
+            name: kubetest-takoyakidath
             port:
               number: 80


### PR DESCRIPTION
## Summary
- fix incorrect service name in `k8s/ingress-nginx.yaml`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889ed02be28832ea759ca12ffd8c452